### PR TITLE
Fixed signs in one of the recurrences' expressions (#218)

### DIFF
--- a/content/math/chapter.tex
+++ b/content/math/chapter.tex
@@ -17,7 +17,7 @@ In general, given an equation $Ax = b$, the solution to a variable $x_i$ is give
 where $A_i'$ is $A$ with the $i$'th column replaced by $b$.
 
 \section{Recurrences}
-If $a_n = c_1 a_{n-1} + \dots + c_k a_{n-k}$, and $r_1, \dots, r_k$ are distinct roots of $x^k + c_1 x^{k-1} + \dots + c_k$, there are $d_1, \dots, d_k$ s.t.
+If $a_n = c_1 a_{n-1} + \dots + c_k a_{n-k}$, and $r_1, \dots, r_k$ are distinct roots of $x^k - c_1 x^{k-1} - \dots - c_k$, there are $d_1, \dots, d_k$ s.t.
 \[a_n = d_1r_1^n + \dots + d_kr_k^n. \]
 Non-distinct roots $r$ become polynomial factors, e.g. $a_n = (d_1n + d_2)r^n$.
 


### PR DESCRIPTION
Seems like minuses should be there, as initial recurrence uses previous values of `a` on the right side of the equation.

Source: Combinatorics and Number Theory lection.

I didn't recompile pdf with this improvement.